### PR TITLE
Add grub2-efi and grub2-extra for EFI support

### DIFF
--- a/iso-pkg-lists-cooker/omdv-lxqt.lst
+++ b/iso-pkg-lists-cooker/omdv-lxqt.lst
@@ -85,6 +85,10 @@ x11-data-cursor-themes
 #xscreensaver-base
 edidbins
 
+# fixes build failure for missing efi stuff for cooker iso
+grub2-efi
+grub2-extra
+
 # MD this entire list should be shuffled or justified to be needed for the full ISO
 
 avahi #service


### PR DESCRIPTION
Added grub2-efi and grub2-extra to fix iso build failure for missing EFI components. https://abf.openmandriva.org/platforms/cooker/products/49/product_build_lists/4397

this fails for missing grub2-efi files on znver1 cooker lxqt iso